### PR TITLE
run_program no longer meters, add run_program_metered

### DIFF
--- a/parasol_cpu/src/proc/fhe_processor.rs
+++ b/parasol_cpu/src/proc/fhe_processor.rs
@@ -222,7 +222,7 @@ impl FheProcessor {
         &mut self,
         inst: IsaOp,
         pc: u32,
-        gas_limit: u32,
+        gas_limit: Option<u32>,
     ) -> Result<(u32, u32)> {
         use crate::tomasulo::{GetDeps, ToDispatchedOp};
 
@@ -249,8 +249,10 @@ impl FheProcessor {
 
         let gas = self.compute_gas(&disp_inst);
 
-        if gas > gas_limit {
-            return Err(Error::OutOfGas(gas, gas_limit));
+        if let Some(gas_limit) = gas_limit {
+            if gas > gas_limit {
+                return Err(Error::OutOfGas(gas, gas_limit));
+            }
         }
 
         scoreboard_entry.set_instruction(&disp_inst);
@@ -666,13 +668,14 @@ impl FheProcessor {
     }
 
     /// Runs the given program using the passed user `data` as arguments with a gas limit
-    /// Returns used gas a program return value
-    pub fn run_program<T: ToArg>(
+    /// Returns the amount of gas used to run the program and the program return
+    /// value
+    pub fn run_program_metered<T: ToArg>(
         &mut self,
         memory: &Arc<Memory>,
         initial_pc: Ptr32,
         args: &Args<T>,
-        gas_limit: u32,
+        gas_limit: Option<u32>,
     ) -> Result<(u32, T)> {
         self.reset()?;
         let return_data = self.set_up_function_call(memory, args)?;
@@ -697,7 +700,14 @@ impl FheProcessor {
                         Error::Halt => break,
                         Error::OutOfGas(used_gas, _) => {
                             self.wait()?;
-                            return Err(Error::OutOfGas(gas + used_gas, gas_limit));
+                            if let Some(gas_limit) = gas_limit {
+                                return Err(Error::OutOfGas(gas + used_gas, gas_limit));
+                            } else {
+                                // This case should never happen since gas
+                                // tracking should throw an out of gas answer
+                                // only when the gas_limit is a Some variant.
+                                unreachable!()
+                            }
                         }
                         _ => return Err(e),
                     },
@@ -717,6 +727,18 @@ impl FheProcessor {
 
         self.try_capture_return_value(memory, args, return_data)
             .map(|ret_val| (gas, ret_val))
+    }
+
+    /// Runs the given program using the passed user `data` as arguments.
+    /// Returns the result of the program.
+    pub fn run_program<T: ToArg>(
+        &mut self,
+        memory: &Arc<Memory>,
+        initial_pc: Ptr32,
+        args: &Args<T>,
+    ) -> Result<T> {
+        self.run_program_metered(memory, initial_pc, args, None)
+            .map(|x| x.1)
     }
 }
 

--- a/parasol_cpu/src/proc/fhe_processor.rs
+++ b/parasol_cpu/src/proc/fhe_processor.rs
@@ -19,18 +19,20 @@ use std::sync::{
     mpsc::{self, Receiver, Sender},
 };
 
-/// Options for running [`FheProcessor::run_program_with_options`]
+/// Options for running [`FheComputer::run_program_with_options`]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct RunProgramOptions {
     gas_limit: Option<u32>,
 }
 
 impl RunProgramOptions {
+    /// Creates a new [`RunProgramOptions`]
     pub fn new() -> Self {
         Self::default()
     }
 
-    fn gas_limit(&self) -> Option<u32> {
+    /// Gas limit for a program before it terminates
+    pub fn gas_limit(&self) -> Option<u32> {
         self.gas_limit
     }
 }
@@ -42,16 +44,18 @@ pub struct RunProgramOptionsBuilder {
 }
 
 impl RunProgramOptionsBuilder {
+    /// Creates a new [`RunProgramOptionsBuilder`]
     pub fn new() -> Self {
         Self::default()
     }
 
-    #[allow(unused)]
+    /// Set the gas limit.
     pub fn gas_limit(mut self, gas_limit: Option<u32>) -> Self {
         self.gas_limit = gas_limit;
         self
     }
 
+    /// Build the run program options into a [`RunProgramOptions`] struct.
     pub fn build(self) -> RunProgramOptions {
         RunProgramOptions {
             gas_limit: self.gas_limit,

--- a/parasol_cpu/src/proc/mod.rs
+++ b/parasol_cpu/src/proc/mod.rs
@@ -266,15 +266,25 @@ impl FheComputer {
     }
 
     /// Run the given FHE program with user specified data and a gas limit, return the used gas and program return value
+    pub fn run_program_metered<T: ToArg>(
+        &mut self,
+        initial_pc: Ptr32,
+        memory: &Arc<Memory>,
+        args: Args<T>,
+        gas_limit: Option<u32>,
+    ) -> Result<(u32, T)> {
+        self.processor
+            .run_program_metered(memory, initial_pc, &args, gas_limit)
+    }
+
+    /// Run the given FHE program with user specified data.
     pub fn run_program<T: ToArg>(
         &mut self,
         initial_pc: Ptr32,
         memory: &Arc<Memory>,
         args: Args<T>,
-        gas_limit: u32,
-    ) -> Result<(u32, T)> {
-        self.processor
-            .run_program(memory, initial_pc, &args, gas_limit)
+    ) -> Result<T> {
+        self.processor.run_program(memory, initial_pc, &args)
     }
 
     /// Run a graph in blocking mode.

--- a/parasol_cpu/src/proc/mod.rs
+++ b/parasol_cpu/src/proc/mod.rs
@@ -1,6 +1,6 @@
 use std::{borrow::BorrowMut, collections::HashMap, sync::Arc};
 
-use fhe_processor::FheProcessor;
+use fhe_processor::{FheProcessor, RunProgramOptions};
 use parasol_concurrency::AtomicRefCell;
 use parasol_runtime::{
     Encryption, Evaluation, FheCircuit, L0LweCiphertext, L1GgswCiphertext, L1GlweCiphertext,
@@ -266,15 +266,15 @@ impl FheComputer {
     }
 
     /// Run the given FHE program with user specified data and a gas limit, return the used gas and program return value
-    pub fn run_program_metered<T: ToArg>(
+    pub fn run_program_with_options<T: ToArg>(
         &mut self,
         initial_pc: Ptr32,
         memory: &Arc<Memory>,
         args: Args<T>,
-        gas_limit: Option<u32>,
+        options: &RunProgramOptions,
     ) -> Result<(u32, T)> {
         self.processor
-            .run_program_metered(memory, initial_pc, &args, gas_limit)
+            .run_program_with_options(memory, initial_pc, &args, options)
     }
 
     /// Run the given FHE program with user specified data.

--- a/parasol_cpu/src/proc/mod.rs
+++ b/parasol_cpu/src/proc/mod.rs
@@ -1,6 +1,7 @@
 use std::{borrow::BorrowMut, collections::HashMap, sync::Arc};
 
-use fhe_processor::{FheProcessor, RunProgramOptions};
+use fhe_processor::FheProcessor;
+pub use fhe_processor::{RunProgramOptions, RunProgramOptionsBuilder};
 use parasol_concurrency::AtomicRefCell;
 use parasol_runtime::{
     Encryption, Evaluation, FheCircuit, L0LweCiphertext, L1GgswCiphertext, L1GlweCiphertext,

--- a/parasol_cpu/src/proc/tests/add.rs
+++ b/parasol_cpu/src/proc/tests/add.rs
@@ -26,9 +26,7 @@ fn can_add_inputs() {
             .arg(MaybeEncryptedUInt::<32>::new(val2 as u64, &enc, &sk, enc2))
             .return_value::<MaybeEncryptedUInt<32>>();
 
-        let (_, result) = proc
-            .run_program(program, &Arc::new(memory), args, 200_000)
-            .unwrap();
+        let result = proc.run_program(program, &Arc::new(memory), args).unwrap();
 
         let ans_sum = result.get(&enc, &sk);
 
@@ -95,9 +93,7 @@ fn can_add_carry_inputs() {
             ))
             .return_value::<[MaybeEncryptedUInt<32>; 2]>();
 
-        let (_, [ans_sum, ans_carry]) = proc
-            .run_program(prog_ptr, &Arc::new(memory), args, 200_000)
-            .unwrap();
+        let [ans_sum, ans_carry] = proc.run_program(prog_ptr, &Arc::new(memory), args).unwrap();
 
         let ans_sum = ans_sum.get(&enc, sk);
         let ans_carry = ans_carry.get(&enc, sk);
@@ -192,8 +188,8 @@ fn add_use_same_dst_and_src() {
 
     let args = ArgsBuilder::new().arg(10u16).return_value::<u16>();
 
-    let (_, actual) = proc
-        .run_program(program_ptr, &Arc::new(memory), args, 200_000)
+    let actual = proc
+        .run_program(program_ptr, &Arc::new(memory), args)
         .unwrap();
 
     assert_eq!(actual, 20);

--- a/parasol_cpu/src/proc/tests/and.rs
+++ b/parasol_cpu/src/proc/tests/and.rs
@@ -19,8 +19,8 @@ fn can_and_plaintext_inputs() {
 
     let args = ArgsBuilder::new().arg(val1).arg(val2).return_value::<u32>();
 
-    let (_, ans) = proc
-        .run_program(program_ptr, &Arc::new(memory), args, 200_000)
+    let ans = proc
+        .run_program(program_ptr, &Arc::new(memory), args)
         .unwrap();
 
     assert_eq!(expected, ans);
@@ -43,9 +43,7 @@ fn can_and_ciphertext_inputs() {
             .arg(UInt::<8, _>::encrypt_secret(val2 as u64, &enc, &sk))
             .return_value::<UInt<8, _>>();
 
-        let (_, answer) = proc
-            .run_program(program, &Arc::new(memory), args, 200_000)
-            .unwrap();
+        let answer = proc.run_program(program, &Arc::new(memory), args).unwrap();
 
         assert_eq!(expected, answer.decrypt(&enc, &sk) as u8);
     };

--- a/parasol_cpu/src/proc/tests/bitshift.rs
+++ b/parasol_cpu/src/proc/tests/bitshift.rs
@@ -48,9 +48,7 @@ fn run_single_test(
         ))
         .return_value::<MaybeEncryptedUInt<8>>();
 
-    let (_, ans) = proc
-        .run_program(program, &Arc::new(memory), args, 200_000)
-        .unwrap();
+    let ans = proc.run_program(program, &Arc::new(memory), args).unwrap();
     let ans = ans.get(enc, &sk);
 
     assert_eq!(

--- a/parasol_cpu/src/proc/tests/branch.rs
+++ b/parasol_cpu/src/proc/tests/branch.rs
@@ -33,9 +33,7 @@ fn can_branch_zero() {
         IsaOp::Ret(),
     ]);
 
-    let (_, ans) = proc
-        .run_program(program, &Arc::new(memory), args, 200_000)
-        .unwrap();
+    let ans = proc.run_program(program, &Arc::new(memory), args).unwrap();
 
     assert_eq!(5, ans);
 }
@@ -64,9 +62,7 @@ fn can_branch_nonzero() {
         IsaOp::Ret(),
     ]);
 
-    let (_, ans) = proc
-        .run_program(program, &Arc::new(memory), args, 200_000)
-        .unwrap();
+    let ans = proc.run_program(program, &Arc::new(memory), args).unwrap();
 
     assert_eq!(0, ans);
 }

--- a/parasol_cpu/src/proc/tests/call_abi.rs
+++ b/parasol_cpu/src/proc/tests/call_abi.rs
@@ -11,12 +11,12 @@ fn unsigned_values_zero_extend_4_byte() {
     let program = memory.allocate_program(&[IsaOp::Ret()]);
 
     let args = ArgsBuilder::new().arg(0x80u8).return_value::<u32>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 0x0000_0080u32);
 
     let args = ArgsBuilder::new().arg(0x8000u16).return_value::<u32>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 0x0000_8000u32);
 }
@@ -30,12 +30,12 @@ fn signed_values_sign_extend_4_byte() {
     let program = memory.allocate_program(&[IsaOp::Ret()]);
 
     let args = ArgsBuilder::new().arg(i8::MIN).return_value::<i32>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, i8::MIN as i32);
 
     let args = ArgsBuilder::new().arg(i16::MIN).return_value::<i32>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, i16::MIN as i32);
 }
@@ -52,7 +52,7 @@ fn eight_byte_vals_2_registers() {
     let args = ArgsBuilder::new()
         .arg(0xDEADBEEF_FEEDF00Du64)
         .return_value::<u64>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 0xDEADBEEF_FEEDF00Du64);
 }
@@ -85,7 +85,7 @@ fn eight_4_byte_args() {
         .arg(1u32)
         .arg(1u32)
         .return_value::<u32>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 8);
 }
@@ -115,7 +115,7 @@ fn four_8_byte_args() {
         .arg(1u64)
         .arg(1u64)
         .return_value::<u32>();
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 4);
 }
@@ -142,7 +142,7 @@ fn large_return_value() {
 
     let args = ArgsBuilder::new().return_value::<[u32; 4]>();
 
-    let (_, ans) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let ans = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(ans[0], 0xDEADBEEF);
     assert_eq!(ans[1], 0xFEEDF00D);
@@ -172,7 +172,7 @@ fn two_large_parameters() {
 
     let args = ArgsBuilder::new().arg(x).arg(y).return_value::<u32>();
 
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 0xFFEEDDCC);
 }
@@ -201,7 +201,7 @@ fn pass_on_stack_wide() {
         IsaOp::Ret(),
     ]);
 
-    let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 0xDEADBEEF_FEEDF00Du64);
 }

--- a/parasol_cpu/src/proc/tests/casting.rs
+++ b/parasol_cpu/src/proc/tests/casting.rs
@@ -91,10 +91,10 @@ fn casting(cast_type: CastType, encrypted_computation: bool) {
             .arg(output_ptr)
             .no_return_value();
 
-        let result = proc.run_program(program, &memory, args, 200_000);
+        let result = proc.run_program(program, &memory, args);
 
         match (valid, result) {
-            (true, Ok((_, ()))) => {
+            (true, Ok(())) => {
                 let ans_bytes = (0..output_width / 8)
                     .map(|x| memory.try_load(output_ptr.try_offset(x).unwrap()).unwrap())
                     .collect::<Vec<_>>();
@@ -131,7 +131,7 @@ fn casting(cast_type: CastType, encrypted_computation: bool) {
                 continue;
             }
             (true, Err(e)) => panic!("Unexpected error: {:?}", e),
-            (false, Ok((_, ()))) => panic!("Expected error"),
+            (false, Ok(())) => panic!("Expected error"),
         }
     }
 }

--- a/parasol_cpu/src/proc/tests/cmux.rs
+++ b/parasol_cpu/src/proc/tests/cmux.rs
@@ -11,32 +11,6 @@ use crate::{
 
 use parasol_runtime::test_utils::get_secret_keys_80;
 
-// Implements this program:
-// [[clang::fhe_circuit]] void cmux(
-//     [[clang::encrypted]] uX_ptr bound_ptr,
-//     [[clang::encrypted]] uX_ptr a_ptr,
-//     [[clang::encrypted]] uX_ptr b_ptr,
-//     [[clang::encrypted]] uX_ptr output_ptr
-// ) {
-//     uX bound = *bound_ptr;
-//     uX a = *a_ptr;
-//     uX b = *b_ptr;
-//
-//     *output_ptr = (bound > 10) ? a : b;
-// }
-// ber     p0, 0
-// ldr     r0, p0
-// ldi     r1, 10
-// gt      r0, r0, r1
-// ber     p2, 2
-// ldr     r1, p2
-// ber     p1, 1
-// ldr     r2, p1
-// cmux    r0, r0, r2, r1
-// berw    p3, 3
-// str     p3, r0
-// ret
-// where ber is BindReadOnly, ldr is Load, ldi is LoadImmediate, gt is GreaterThan, berw is BindReadWrite, str is Store, and ret is Return
 fn cmux_test_program() -> Vec<IsaOp> {
     vec![
         IsaOp::LoadI(T0, 10, 32),
@@ -84,7 +58,7 @@ fn can_cmux(encrypted_computation: bool) {
 
         let program = memory.allocate_program(&cmux_test_program());
 
-        let (_, ans) = proc.run_program(program, &memory, args, 200_000).unwrap();
+        let ans = proc.run_program(program, &memory, args).unwrap();
 
         assert_eq!(expected, ans.get(&enc, &sk));
     }

--- a/parasol_cpu/src/proc/tests/comparisons.rs
+++ b/parasol_cpu/src/proc/tests/comparisons.rs
@@ -61,7 +61,7 @@ fn run_single_test(
     };
     let args = args.return_value::<MaybeEncryptedUInt<32>>();
 
-    let (_, ans) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let ans = proc.run_program(program, &memory, args).unwrap();
     assert_eq!(expected as u32, ans.get(enc, &sk));
 }
 

--- a/parasol_cpu/src/proc/tests/load_store.rs
+++ b/parasol_cpu/src/proc/tests/load_store.rs
@@ -32,7 +32,7 @@ fn can_load_store_plain_bit_width() {
             .arg(output_ptr)
             .no_return_value();
 
-        proc.run_program(program, &memory, args, 200_000).unwrap();
+        proc.run_program(program, &memory, args).unwrap();
 
         let bytes = width / 8;
 
@@ -86,7 +86,7 @@ fn can_load_store_ciphertext_bit_width() {
 
         let args = ArgsBuilder::new().arg(src).arg(dst).no_return_value();
 
-        proc.run_program(program, &memory, args, 100).unwrap();
+        proc.run_program(program, &memory, args).unwrap();
 
         let bytes = (width / 8) as usize;
 
@@ -120,7 +120,7 @@ fn can_load_immediate() {
 
     let program = memory.allocate_program(&[IsaOp::LoadI(A0, 1234, 15), IsaOp::Ret()]);
 
-    let (_, result) = proc.run_program(program, &memory, args, 100).unwrap();
+    let result = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(result, 1234u16);
 }
@@ -137,7 +137,6 @@ fn load_immediate_fails_out_of_range() {
         memory.allocate_program(&[IsaOp::LoadI(A0, 1234, 4), IsaOp::Ret()]),
         &memory,
         args,
-        200_000,
     );
 
     assert!(matches!(
@@ -157,7 +156,7 @@ fn can_offset_load() {
 
     let args = ArgsBuilder::new().arg(src).return_value::<u16>();
 
-    let (_, actual) = proc
+    let actual = proc
         .run_program(
             memory.allocate_program(&[
                 IsaOp::LoadI(T0, 2, 32),
@@ -167,7 +166,6 @@ fn can_offset_load() {
             ]),
             &memory,
             args,
-            200_000,
         )
         .unwrap();
 

--- a/parasol_cpu/src/proc/tests/mul.rs
+++ b/parasol_cpu/src/proc/tests/mul.rs
@@ -43,7 +43,7 @@ fn can_unsigned_mul_plain_plain() {
             .arg(c_ptr)
             .no_return_value();
 
-        proc.run_program(program, &memory, args, 100).unwrap();
+        proc.run_program(program, &memory, args).unwrap();
 
         let mask = get_mask(width);
 
@@ -86,7 +86,7 @@ where
             .arg(MaybeEncryptedUInt::<N>::new(b, &enc, &sk, b_enc))
             .return_value::<MaybeEncryptedUInt<N>>();
 
-        let (_, actual) = proc.run_program(program, &memory, args, 500_000).unwrap();
+        let actual = proc.run_program(program, &memory, args).unwrap();
 
         let expected = a.wrapping_mul(b) & ((0x1 << N) - 1);
         let actual: u64 = actual.get(&enc, &sk).into();

--- a/parasol_cpu/src/proc/tests/neg.rs
+++ b/parasol_cpu/src/proc/tests/neg.rs
@@ -15,7 +15,7 @@ fn can_neg_plaintext_inputs() {
 
     let program = memory.allocate_program(&[IsaOp::Neg(A0, A0), IsaOp::Ret()]);
 
-    let (_, ans) = proc.run_program(program, &memory, args, 100).unwrap();
+    let ans = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(expected, ans);
 }

--- a/parasol_cpu/src/proc/tests/not.rs
+++ b/parasol_cpu/src/proc/tests/not.rs
@@ -30,7 +30,7 @@ fn can_not(val: u32, encrypted_computation: bool) {
 
     let program = memory.allocate_program(&[IsaOp::Not(A0, A0), IsaOp::Ret()]);
 
-    let (_, ans) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let ans = proc.run_program(program, &memory, args).unwrap();
     let ans = ans.get(&enc, &sk);
 
     assert_eq!(expected, ans);

--- a/parasol_cpu/src/proc/tests/or.rs
+++ b/parasol_cpu/src/proc/tests/or.rs
@@ -20,7 +20,7 @@ fn can_or_plaintext_inputs() {
 
     let args = ArgsBuilder::new().arg(val1).arg(val2).return_value::<u32>();
 
-    let (_, ans) = proc.run_program(program, &memory, args, 100).unwrap();
+    let ans = proc.run_program(program, &memory, args).unwrap();
 
     assert_eq!(expected, ans);
 }
@@ -42,7 +42,7 @@ fn can_or_ciphertext_inputs() {
             .arg(UInt::<8, _>::encrypt_secret(val2 as u64, &enc, &sk))
             .return_value::<UInt<8, _>>();
 
-        let (_, answer) = proc.run_program(program, &memory, args, 200_000).unwrap();
+        let answer = proc.run_program(program, &memory, args).unwrap();
 
         let answer = answer.decrypt(&enc, &sk) as u8;
 

--- a/parasol_cpu/src/proc/tests/sub.rs
+++ b/parasol_cpu/src/proc/tests/sub.rs
@@ -26,7 +26,7 @@ fn can_sub_inputs() {
 
         let program = memory.allocate_program(&[IsaOp::Sub(A0, A0, A1), IsaOp::Ret()]);
 
-        let (_, ans_sum) = proc.run_program(program, &memory, args, 200_000).unwrap();
+        let ans_sum = proc.run_program(program, &memory, args).unwrap();
 
         let ans_sum = ans_sum.get(&enc, &sk);
 
@@ -86,7 +86,7 @@ fn can_sub_borrow_inputs() {
             .return_value::<[MaybeEncryptedUInt<8>; 5]>();
 
         // Diff || borrow is 5 bytes: 4 for the difference and 1 for the borrow
-        let (_, result) = proc.run_program(program, &memory, args, 200_000).unwrap();
+        let result = proc.run_program(program, &memory, args).unwrap();
 
         let ans_diff = u32::from_le_bytes(
             result
@@ -184,12 +184,11 @@ fn sub_use_same_dst_and_src() {
 
     let args = ArgsBuilder::new().arg(10u32).return_value::<u32>();
 
-    let (_, ans) = proc
+    let ans = proc
         .run_program(
             memory.allocate_program(&[IsaOp::Sub(A0, A0, A0), IsaOp::Ret()]),
             &memory,
             args,
-            100,
         )
         .unwrap();
 

--- a/parasol_cpu/src/proc/tests/xor.rs
+++ b/parasol_cpu/src/proc/tests/xor.rs
@@ -36,7 +36,7 @@ fn can_xor(val1: u32, val2: u32, encrypted_val1: bool, encrypted_val2: bool) {
         ))
         .return_value::<MaybeEncryptedUInt<32>>();
 
-    let (_, ans) = proc.run_program(program, &memory, args, 200_000).unwrap();
+    let ans = proc.run_program(program, &memory, args).unwrap();
     let ans = ans.get(&enc, &sk);
 
     assert_eq!(expected, ans);

--- a/parasol_cpu/tests/e2e_tests/add.rs
+++ b/parasol_cpu/tests/e2e_tests/add.rs
@@ -24,7 +24,7 @@ fn can_run_from_elf() {
 
     let prog = memory.get_function_entry("add").unwrap();
 
-    let result = proc.run_program(prog, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(prog, &memory, args).unwrap();
 
-    assert_eq!(result.1.decrypt(&enc, sk), 96);
+    assert_eq!(result.decrypt(&enc, sk), 96);
 }

--- a/parasol_cpu/tests/e2e_tests/cardio.rs
+++ b/parasol_cpu/tests/e2e_tests/cardio.rs
@@ -42,5 +42,5 @@ fn can_run_from_elf() {
 
     let result = proc.run_program(prog, &memory, args).unwrap();
 
-    assert_eq!(result.decrypt(&enc, &sk), 3);
+    assert_eq!(result.decrypt(&enc, sk), 3);
 }

--- a/parasol_cpu/tests/e2e_tests/cardio.rs
+++ b/parasol_cpu/tests/e2e_tests/cardio.rs
@@ -40,7 +40,7 @@ fn can_run_from_elf() {
 
     let prog = memory.get_function_entry("cardio").unwrap();
 
-    let result = proc.run_program(prog, &memory, args, 3_000_000).unwrap();
+    let result = proc.run_program(prog, &memory, args).unwrap();
 
-    assert_eq!(result.1.decrypt(&enc, sk), 3);
+    assert_eq!(result.decrypt(&enc, &sk), 3);
 }

--- a/parasol_cpu/tests/e2e_tests/chi_sq.rs
+++ b/parasol_cpu/tests/e2e_tests/chi_sq.rs
@@ -30,7 +30,7 @@ fn can_run_from_elf() {
 
     let prog = memory.get_function_entry("chi_sq").unwrap();
 
-    proc.run_program(prog, &memory, args, 3_000_000).unwrap();
+    proc.run_program(prog, &memory, args).unwrap();
 
     let result = memory.try_load_type::<[UInt<16, _>; 4]>(result).unwrap();
 

--- a/parasol_cpu/tests/e2e_tests/cmux.rs
+++ b/parasol_cpu/tests/e2e_tests/cmux.rs
@@ -25,9 +25,9 @@ fn can_run_from_elf() {
 
     let prog = memory.get_function_entry("cmux").unwrap();
 
-    let result = proc.run_program(prog, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(prog, &memory, args).unwrap();
 
-    assert_eq!(result.1.decrypt(&enc, sk), 54);
+    assert_eq!(result.decrypt(&enc, sk), 54);
 
     let args = ArgsBuilder::new()
         .arg(UInt::<8, _>::encrypt_secret(10, &enc, sk))
@@ -35,7 +35,7 @@ fn can_run_from_elf() {
         .arg(UInt::<8, _>::encrypt_secret(11, &enc, sk))
         .return_value::<UInt<8, _>>();
 
-    let result = proc.run_program(prog, &memory, args, 200_000).unwrap();
+    let result = proc.run_program(prog, &memory, args).unwrap();
 
-    assert_eq!(result.1.decrypt(&enc, sk), 11);
+    assert_eq!(result.decrypt(&enc, sk), 11);
 }

--- a/parasol_cpu/tests/e2e_tests/vector_add.rs
+++ b/parasol_cpu/tests/e2e_tests/vector_add.rs
@@ -29,7 +29,7 @@ fn can_run_from_elf() {
 
     let prog = memory.get_function_entry("vector_add").unwrap();
 
-    proc.run_program(prog, &memory, args, 5_000_000).unwrap();
+    proc.run_program(prog, &memory, args).unwrap();
 
     let result = memory
         .try_load_type::<[UInt<8, _>; 8]>(c)


### PR DESCRIPTION
Metering is used more for services that deploy the HPU, versus just running the programs locally. We use `run_program` without any meaningful gas limit far more than we run it with one. Hence this PR makes the default to have no gas limit at all and adds a `run_program_metered` that does meter the processor. 

Note that one can run `run_program_metered` with a `None` limit to get out the amount of gas used by a computation without specifying a gas limit. 