### PR TITLE
Fix and improve immediate number check and tests

### DIFF
--- a/parasol_cpu/src/proc/assembly.rs
+++ b/parasol_cpu/src/proc/assembly.rs
@@ -357,7 +357,7 @@ define_op! {
     [0x02 Load (dst dst, 0, Register) (src src, 0, Register) (cmeta width, 7, u32, width_dec, width_enc)],
 
     // Load immediate
-    [0x03 LoadI (dst dst, 0, Register) (meta imm, 32, i32) (cmeta width, 7, u32, width_dec, width_enc)],
+    [0x03 LoadI (dst dst, 0, Register) (meta imm, 32, u32) (cmeta width, 7, u32, width_dec, width_enc)],
 
     // Store
     [0x04 Store (src dst, 0, Register) (src src, 0, Register) (cmeta width, 7, u32, width_dec, width_enc)],

--- a/parasol_cpu/src/proc/ops/loadi.rs
+++ b/parasol_cpu/src/proc/ops/loadi.rs
@@ -10,7 +10,7 @@ impl FheProcessor {
         &mut self,
         retirement_info: RetirementInfo<DispatchIsaOp>,
         dst: RobEntryRef<Register>,
-        imm: i32,
+        imm: u32,
         width: u32,
         instruction_id: usize,
         pc: u32,
@@ -18,20 +18,21 @@ impl FheProcessor {
         let loadi_impl = || -> Result<()> {
             unwrap_registers!((mut dst));
 
-            // Sign extend imm
-            let imm = imm as i128;
+            // check if the immediate number is out of range
+            // a caveat that is LLVM will sign extend the immediate to 32 bit
+            // if it's smaller than 32 bit, for example, in `ldi x10, -90, 8`
+            // the number -90 in 2's complement with 8 bit will be 0xA6, but
+            // in the encoding we have 32 bit for the immediate so it's
+            // 0xFFFFFFA6, not 0x000000A6
+            let in_range_unsigned = (imm as u64) < (1 << width);
+            let in_range_signed_neg = (imm | ((1 << (width - 1)) - 1)) == 0xFFFFFFFF;
 
-            // 2s complement features 1 more negative value than positive.
-            // Hence the >= vs < mismatch.
-            if (imm.is_positive() && imm >= 0x1 << (width - 1))
-                || (imm.is_negative() && imm < -1 << (width - 1))
-            {
+            if !in_range_unsigned && !in_range_signed_neg {
                 return Err(Error::out_of_range(instruction_id, pc));
             }
 
-            // Bitcast imm from i128 to u128.
             *dst = Register::Plaintext {
-                val: imm as u128,
+                val: imm as u128 & ((1 << width) - 1),
                 width,
             };
 

--- a/parasol_cpu/src/proc/ops/loadi.rs
+++ b/parasol_cpu/src/proc/ops/loadi.rs
@@ -25,7 +25,7 @@ impl FheProcessor {
             // in the encoding we have 32 bit for the immediate so it's
             // 0xFFFFFFA6, not 0x000000A6
             let in_range_unsigned = (imm as u64) < (1 << width);
-            let in_range_signed_neg = (imm | ((1 << (width - 1)) - 1)) == 0xFFFFFFFF;
+            let in_range_signed_neg = imm >= 0xFFFFFFFF << (width - 1);
 
             if !in_range_unsigned && !in_range_signed_neg {
                 return Err(Error::out_of_range(instruction_id, pc));

--- a/parasol_cpu/src/proc/tests/call_abi.rs
+++ b/parasol_cpu/src/proc/tests/call_abi.rs
@@ -127,8 +127,8 @@ fn large_return_value() {
     let memory = Arc::new(Memory::new_default_stack());
 
     let program = memory.allocate_program(&[
-        IsaOp::LoadI(T0, 0xDEADBEEFu32 as i32, 32),
-        IsaOp::LoadI(T1, 0xFEEDF00Du32 as i32, 32),
+        IsaOp::LoadI(T0, 0xDEADBEEF, 32),
+        IsaOp::LoadI(T1, 0xFEEDF00D, 32),
         IsaOp::LoadI(T2, 4, 32),
         IsaOp::Store(A0, T0, 32),
         IsaOp::Add(A0, A0, T2),

--- a/parasol_cpu/src/proc/tests/load_store.rs
+++ b/parasol_cpu/src/proc/tests/load_store.rs
@@ -123,6 +123,8 @@ fn can_load_immediate() {
         (0xF0, 8),
         // 0xFFFFFF30 is 0b1..100110000 which is at least 9 bits long as signed negative (or 32 bits as unsigned)
         (0xFFFFFF30, 9),
+        // 0xFFFFFFE0 is 0b1..111100000 which is at least 6 bits long as signed negative (or 32 bits as unsigned)
+        (0xFFFFFFE0, 6),
     ] {
         let args = ArgsBuilder::new().return_value::<u32>();
 
@@ -141,7 +143,7 @@ fn load_immediate_fails_out_of_range() {
     let memory = Arc::new(Memory::new_default_stack());
 
     // see test above for why these values are chosen
-    for (val, width) in [(0x30, 5), (0xF0, 7), (0xFFFFFF30, 8)] {
+    for (val, width) in [(0x30, 5), (0xF0, 7), (0xFFFFFF30, 8), (0xFFFFFFE0, 5)] {
         let args = ArgsBuilder::new().return_value::<u32>();
 
         let result = proc.run_program(


### PR DESCRIPTION
Note the old check isn't actually correct, for example, if the width is 8, then for positive numbers, it'll require it to be under 128, but that's not true, because we do not know if the immediate will be used for signed or unsigned, it's possible it's used for unsigned, and 8 bit width allows for [128, 256).