### PR TITLE
Make word size a constant

### DIFF
--- a/parasol_cpu/src/proc/fhe_processor.rs
+++ b/parasol_cpu/src/proc/fhe_processor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Allocation, Byte, Extend, Memory, Result, Word,
+    Allocation, Byte, Extend, INSTRUCTION_SIZE, Memory, Result, Word,
     register_names::*,
     tomasulo::{
         registers::{RegisterFile, RegisterName, RobEntryRef},
@@ -1018,7 +1018,7 @@ impl Tomasulo for FheProcessor {
                     if *val != 0 {
                         Ok(pc.wrapping_add_signed(pc_offset))
                     } else {
-                        Ok(pc + 8)
+                        Ok(pc + INSTRUCTION_SIZE)
                     }
                 } else {
                     Err(Error::BranchConditionNotPlaintext)
@@ -1030,7 +1030,7 @@ impl Tomasulo for FheProcessor {
                     if *val == 0 {
                         Ok(pc.wrapping_add_signed(pc_offset))
                     } else {
-                        Ok(pc + 8)
+                        Ok(pc + INSTRUCTION_SIZE)
                     }
                 } else {
                     Err(Error::BranchConditionNotPlaintext)
@@ -1038,7 +1038,7 @@ impl Tomasulo for FheProcessor {
             }
             DispatchIsaOp::Branch(pc_offset) => Ok(pc.wrapping_add_signed(pc_offset)),
             DispatchIsaOp::Ret() => Err(Error::Halt),
-            _ => Ok(pc + 8),
+            _ => Ok(pc + INSTRUCTION_SIZE),
         }
     }
 }


### PR DESCRIPTION
The point of this PR is to change the magic values of `4` and `8` into meanings based on the word size of the processor. I may have missed parts, but at least this is a start.