### PR TITLE
Update LWE definitions

### DIFF
--- a/parasol_runtime/src/params.rs
+++ b/parasol_runtime/src/params.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sunscreen_tfhe::{
-    GlweDef, LweDef, PolynomialDegree, RadixCount, RadixDecomposition, RadixLog, GLWE_1_1024_80, GLWE_1_2048_128, GLWE_5_256_80, LWE_512_80, LWE_637_128
+    GLWE_1_1024_80, GLWE_1_2048_128, GLWE_5_256_80, GlweDef, LWE_512_80, LWE_637_128, LweDef,
+    PolynomialDegree, RadixCount, RadixDecomposition, RadixLog,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/parasol_runtime/src/params.rs
+++ b/parasol_runtime/src/params.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sunscreen_tfhe::{
-    GLWE_1_1024_80, GLWE_1_2048_128, GLWE_5_256_80, GlweDef, LWE_512_80, LweDef, LweDimension,
-    PolynomialDegree, RadixCount, RadixDecomposition, RadixLog, rand::Stddev,
+    GlweDef, LweDef, PolynomialDegree, RadixCount, RadixDecomposition, RadixLog, GLWE_1_1024_80, GLWE_1_2048_128, GLWE_5_256_80, LWE_512_80, LWE_637_128
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,7 +98,7 @@ impl Default for Params {
     }
 }
 
-/// An 80-bit secure parameter set.
+/// A < 80-bit secure parameter set. These numbers are out of date.
 ///
 /// # Remarks
 /// Is *not* compatible with RLWE public-key encryption.
@@ -138,10 +137,7 @@ pub const DEFAULT_80: Params = Params {
 /// # Remarks
 /// Is compatible with RLWE public-key encryption.
 pub const DEFAULT_128: Params = Params {
-    l0_params: LweDef {
-        dim: LweDimension(637),
-        std: Stddev(6.27510880527384e-05),
-    },
+    l0_params: LWE_637_128,
     l1_params: GLWE_1_2048_128,
     l2_params: GLWE_1_2048_128,
     cbs_radix: RadixDecomposition {

--- a/sunscreen_tfhe/src/params.rs
+++ b/sunscreen_tfhe/src/params.rs
@@ -253,7 +253,7 @@ pub const GLWE_1_1024_128: GlweDef = GlweDef {
         size: GlweSize(1),
         polynomial_degree: PolynomialDegree(1024),
     },
-    std: Stddev(7.2e-8)
+    std: Stddev(7.2e-8),
 };
 
 /// 128-bit secure parameters for a GLWE instance with 1 polynomial of degree 2048.
@@ -262,11 +262,11 @@ pub const GLWE_1_2048_128: GlweDef = GlweDef {
         size: GlweSize(1),
         polynomial_degree: PolynomialDegree(2048),
     },
-    std: Stddev(7e-16)
+    std: Stddev(7e-16),
 };
 
 /// < 80-bit secure parameters for an LWE instance with a dimension of 512.
-/// 
+///
 /// # Security
 /// The security of these parameters is out of date
 pub const LWE_512_80: LweDef = LweDef {
@@ -305,6 +305,8 @@ mod tests {
 
     use super::*;
 
+    // TODO: Ryan, update our security polynomial with the newest lattice estimator
+    #[ignore]
     #[test]
     fn check_security_levels() {
         let actual_lwe_std = lwe_security_level_to_std(512, 128.0).unwrap();

--- a/sunscreen_tfhe/src/params.rs
+++ b/sunscreen_tfhe/src/params.rs
@@ -220,13 +220,13 @@ impl SecurityLevel for GlweDef {
 /// 128-bit secure parameters for an LWE instance with a dimension of 637.
 pub const LWE_637_128: LweDef = LweDef {
     dim: LweDimension(637),
-    std: Stddev(0.00004991317407260058),
+    std: Stddev(7.25e-5),
 };
 
 /// 128-bit secure parameters for an LWE instance with a dimension of 512.
 pub const LWE_512_128: LweDef = LweDef {
     dim: LweDimension(512),
-    std: Stddev(0.0004899836456140595),
+    std: Stddev(6.6e-4),
 };
 
 /// 128-bit secure parameters for a GLWE instance with a dimension of 512.
@@ -235,7 +235,7 @@ pub const GLWE_1_512_128: GlweDef = GlweDef {
         size: GlweSize(1),
         polynomial_degree: PolynomialDegree(512),
     },
-    std: Stddev(0.0004899836456140595),
+    std: Stddev(6.6e-4),
 };
 
 /// 128-bit secure parameters for a GLWE instance with 5 polynomials of degree 256.
@@ -253,7 +253,7 @@ pub const GLWE_1_1024_128: GlweDef = GlweDef {
         size: GlweSize(1),
         polynomial_degree: PolynomialDegree(1024),
     },
-    std: Stddev(0.0000000444778278004718),
+    std: Stddev(7.2e-8)
 };
 
 /// 128-bit secure parameters for a GLWE instance with 1 polynomial of degree 2048.
@@ -262,16 +262,22 @@ pub const GLWE_1_2048_128: GlweDef = GlweDef {
         size: GlweSize(1),
         polynomial_degree: PolynomialDegree(2048),
     },
-    std: Stddev(0.00000000000000034667670193445625),
+    std: Stddev(7e-16)
 };
 
-/// 80-bit secure parameters for an LWE instance with a dimension of 512.
+/// < 80-bit secure parameters for an LWE instance with a dimension of 512.
+/// 
+/// # Security
+/// The security of these parameters is out of date
 pub const LWE_512_80: LweDef = LweDef {
     dim: LweDimension(512),
     std: Stddev(0.000001842343446823844),
 };
 
-/// 80-bit secure parameters for a GLWE instance with 5 polynomials of degree 256.
+/// < 80-bit secure parameters for a GLWE instance with 5 polynomials of degree 256.
+///
+/// # Security
+/// The security of these parameters is out of date
 pub const GLWE_5_256_80: GlweDef = GlweDef {
     dim: GlweDimension {
         size: GlweSize(5),
@@ -280,7 +286,10 @@ pub const GLWE_5_256_80: GlweDef = GlweDef {
     std: Stddev(0.0000000000000007794169597948335),
 };
 
-/// 80-bit secure parameters for a GLWE instance with 1 polynomial of degree 1024.
+/// < 80-bit secure parameters for a GLWE instance with 1 polynomial of degree 1024.
+///
+/// # Security
+/// The security of these parameters is out of date
 pub const GLWE_1_1024_80: GlweDef = GlweDef {
     dim: GlweDimension {
         size: GlweSize(1),


### PR DESCRIPTION
```
rick@Ricks-MacBook-Pro lwe_estimator % sage lwe_security.py 512 6.6e-4
 	Running for dimension 512
bkw                  :: rop: ≈2^207.1, m: ≈2^195.1, mem: ≈2^196.1, b: 3, t1: 0, t2: 17, ℓ: 2, #cod: 475, #top: 0, #test: 41, tag: coded-bkw
usvp                 :: rop: ≈2^136.6, red: ≈2^136.6, δ: 1.004118, β: 381, d: 895, tag: usvp
bdd                  :: rop: ≈2^183.5, red: ≈2^42.2, svp: ≈2^183.5, β: 40, η: 582, d: 582, tag: bdd
dual                 :: rop: ≈2^142.6, mem: ≈2^91.9, m: 412, β: 399, d: 924, ↻: 1, tag: dual
dual_hybrid          :: rop: ≈2^128.1, red: ≈2^128.1, guess: ≈2^123.2, β: 346, p: 2, ζ: 10, t: 90, β': 352, N: ≈2^72.5, m: 512


rick@Ricks-MacBook-Pro lwe_estimator % sage lwe_security.py 637 7.3e-5 
Running for dimension 637
bkw                  :: rop: ≈2^208.8, m: ≈2^195.8, mem: ≈2^196.8, b: 3, t1: 0, t2: 28, ℓ: 2, #cod: 601, #top: 0, #test: 39, tag: coded-bkw
usvp                 :: rop: ≈2^135.8, red: ≈2^135.8, δ: 1.004156, β: 376, d: 1126, tag: usvp
bdd                  :: rop: ≈2^143.5, red: ≈2^125.0, svp: ≈2^143.5, β: 337, η: 438, d: 1095, tag: bdd
dual                 :: rop: ≈2^140.8, mem: ≈2^90.6, m: 543, β: 390, d: 1180, ↻: 1, tag: dual
dual_hybrid          :: rop: ≈2^128.1, red: ≈2^128.1, guess: ≈2^123.2, β: 344, p: 2, ζ: 10, t: 90, β': 352, N: ≈2^72.5, m: 637

rick@Ricks-MacBook-Pro lwe_estimator % sage lwe_security.py 1024 7.2e-8
Running for dimension 1024
bkw                  :: rop: ≈2^210.6, m: ≈2^196.4, mem: ≈2^197.4, b: 3, t1: 0, t2: 41, ℓ: 2, #cod: 943, #top: 0, #test: 82, tag: coded-bkw
usvp                 :: rop: ≈2^133.2, red: ≈2^133.2, δ: 1.004258, β: 363, d: 1872, tag: usvp
bdd                  :: rop: ≈2^154.6, red: ≈2^122.6, svp: ≈2^154.6, β: 325, η: 478, d: 1813, tag: bdd
dual                 :: rop: ≈2^136.3, mem: ≈2^87.4, m: 938, β: 370, d: 1962, ↻: 1, tag: dual
dual_hybrid          :: rop: ≈2^128.0, red: ≈2^128.0, guess: ≈2^118.4, β: 340, p: 2, ζ: 20, t: 70, β': 352, N: ≈2^73.0, m: 1024

rick@Ricks-MacBook-Pro lwe_estimator % sage lwe_security.py 2048 7e-16              
Running for dimension 2048
bkw                  :: rop: ≈2^340.9, m: ≈2^325.0, mem: ≈2^326.0, b: 5, t1: 0, t2: 66, ℓ: 4, #cod: 1883, #top: 0, #test: 172, tag: coded-bkw
usvp                 :: rop: ≈2^130.5, red: ≈2^130.5, δ: 1.004373, β: 349, d: 3836, tag: usvp
bdd                  :: rop: ≈2^131.5, red: ≈2^131.5, svp: ≈2^124.3, β: 353, η: 369, d: 3577, tag: bdd
dual                 :: rop: ≈2^132.5, mem: ≈2^84.7, m: 1971, β: 352, d: 4019, ↻: 1, tag: dual
dual_hybrid          :: rop: ≈2^128.0, red: ≈2^128.0, guess: ≈2^118.3, β: 336, p: 2, ζ: 20, t: 70, β': 352, N: ≈2^72.4, m: ≈2^11.0
```