### PR TITLE
Int aliases

### DIFF
--- a/parasol_runtime/src/fluent/int.rs
+++ b/parasol_runtime/src/fluent/int.rs
@@ -1,4 +1,4 @@
-use crate::circuits::mul::append_int_multiply;
+use crate::{L1GlweCiphertext, circuits::mul::append_int_multiply};
 
 use super::{
     FheCircuit, Muxable, PackedGenericInt,
@@ -57,6 +57,42 @@ pub type DynamicInt<T> = DynamicGenericInt<T, Signed>;
 
 /// Signed variant for [`PackedDynamicGenericInt`]
 pub type PackedDynamicInt<T> = PackedDynamicGenericInt<T, Signed>;
+
+/// Encrypted signed 8 bit integer. This is a specialization of [`Int`] for 8 bits and [`L1GlweCiphertext`].
+pub type Int8 = Int<8, L1GlweCiphertext>;
+
+/// Encrypted signed 16 bit integer. This is a specialization of [`Int`] for 16 bits and [`L1GlweCiphertext`].
+pub type Int16 = Int<16, L1GlweCiphertext>;
+
+/// Encrypted signed 32 bit integer. This is a specialization of [`Int`] for 32 bits and [`L1GlweCiphertext`].
+pub type Int32 = Int<32, L1GlweCiphertext>;
+
+/// Encrypted signed 64 bit integer. This is a specialization of [`Int`] for 64 bits and [`L1GlweCiphertext`].
+pub type Int64 = Int<64, L1GlweCiphertext>;
+
+/// Encrypted signed 128 bit integer. This is a specialization of [`Int`] for 128 bits and [`L1GlweCiphertext`].
+pub type Int128 = Int<128, L1GlweCiphertext>;
+
+/// Encrypted signed 256 bit integer. This is a specialization of [`Int`] for 256 bits and [`L1GlweCiphertext`].
+pub type Int256 = Int<256, L1GlweCiphertext>;
+
+/// Encrypted packed signed 8 bit integer. This is a specialization of [`PackedInt`] for 8 bits and [`L1GlweCiphertext`].
+pub type PackedInt8 = PackedInt<8, L1GlweCiphertext>;
+
+/// Encrypted packed signed 16 bit integer. This is a specialization of [`PackedInt`] for 16 bits and [`L1GlweCiphertext`].
+pub type PackedInt16 = PackedInt<16, L1GlweCiphertext>;
+
+/// Encrypted packed signed 32 bit integer. This is a specialization of [`PackedInt`] for 32 bits and [`L1GlweCiphertext`].
+pub type PackedInt32 = PackedInt<32, L1GlweCiphertext>;
+
+/// Encrypted packed signed 64 bit integer. This is a specialization of [`PackedInt`] for 64 bits and [`L1GlweCiphertext`].
+pub type PackedInt64 = PackedInt<64, L1GlweCiphertext>;
+
+/// Encrypted packed signed 128 bit integer. This is a specialization of [`PackedInt`] for 128 bits and [`L1GlweCiphertext`].
+pub type PackedInt128 = PackedInt<128, L1GlweCiphertext>;
+
+/// Encrypted packed 256 bit integer. This is a specialization of [`PackedInt`] for 256 bits and [`L1GlweCiphertext`].
+pub type PackedInt256 = PackedInt<256, L1GlweCiphertext>;
 
 #[cfg(test)]
 mod tests {

--- a/parasol_runtime/src/fluent/uint.rs
+++ b/parasol_runtime/src/fluent/uint.rs
@@ -1,4 +1,4 @@
-use crate::circuits::mul::append_uint_multiply;
+use crate::{L1GlweCiphertext, circuits::mul::append_uint_multiply};
 
 use super::{
     FheCircuit, Muxable, PackedGenericInt,
@@ -57,6 +57,42 @@ pub type DynamicUInt<T> = DynamicGenericInt<T, Unsigned>;
 
 /// Unsigned variant for [`PackedDynamicGenericInt`]
 pub type PackedDynamicUInt<T> = PackedDynamicGenericInt<T, Unsigned>;
+
+/// Encrypted unsigned 8 bit integer. This is a specialization of [`UInt`] for 8 bits and [`L1GlweCiphertext`].
+pub type UInt8 = UInt<8, L1GlweCiphertext>;
+
+/// Encrypted unsigned 16 bit integer. This is a specialization of [`UInt`] for 16 bits and [`L1GlweCiphertext`].
+pub type UInt16 = UInt<16, L1GlweCiphertext>;
+
+/// Encrypted unsigned 32 bit integer. This is a specialization of [`UInt`] for 32 bits and [`L1GlweCiphertext`].
+pub type UInt32 = UInt<32, L1GlweCiphertext>;
+
+/// Encrypted unsigned 64 bit integer. This is a specialization of [`UInt`] for 64 bits and [`L1GlweCiphertext`].
+pub type UInt64 = UInt<64, L1GlweCiphertext>;
+
+/// Encrypted unsigned 128 bit integer. This is a specialization of [`UInt`] for 128 bits and [`L1GlweCiphertext`].
+pub type UInt128 = UInt<128, L1GlweCiphertext>;
+
+/// Encrypted unsigned 256 bit integer. This is a specialization of [`UInt`] for 256 bits and [`L1GlweCiphertext`].
+pub type UInt256 = UInt<256, L1GlweCiphertext>;
+
+/// Encrypted packed unsigned 8 bit integer. This is a specialization of [`PackedUInt`] for 8 bits and [`L1GlweCiphertext`].
+pub type PackedUInt8 = PackedUInt<8, L1GlweCiphertext>;
+
+/// Encrypted packed unsigned 16 bit integer. This is a specialization of [`PackedUInt`] for 16 bits and [`L1GlweCiphertext`].
+pub type PackedUInt16 = PackedUInt<16, L1GlweCiphertext>;
+
+/// Encrypted packed unsigned 32 bit integer. This is a specialization of [`PackedUInt`] for 32 bits and [`L1GlweCiphertext`].
+pub type PackedUInt32 = PackedUInt<32, L1GlweCiphertext>;
+
+/// Encrypted packed unsigned 64 bit integer. This is a specialization of [`PackedUInt`] for 64 bits and [`L1GlweCiphertext`].
+pub type PackedUInt64 = PackedUInt<64, L1GlweCiphertext>;
+
+/// Encrypted packed unsigned 128 bit integer. This is a specialization of [`PackedUInt`] for 128 bits and [`L1GlweCiphertext`].
+pub type PackedUInt128 = PackedUInt<128, L1GlweCiphertext>;
+
+/// Encrypted packed unsigned 256 bit integer. This is a specialization of [`PackedUInt`] for 256 bits and [`L1GlweCiphertext`].
+pub type PackedUInt256 = PackedUInt<256, L1GlweCiphertext>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Adds aliases for common integer types. These are all specified to the ciphertext types that the user would be using (L1Glwes).